### PR TITLE
Add functionality

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Alasdair Nicol
+Copyright (c) 2015, Alasdair Nicol, Gregor Herrmann, Philipp Spitzer
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,46 @@ django-genshi-template
 ======================
 
 **django-genshi-template** is a template backend that allows you to use Genshi with Django 1.8+
+
+The following context variable are already pre-configured and usable:
+    * 'static'     # staticfiles_storage.url
+    * 'url'        # reverse
+    * 'request'    # request
+    * 'csrf_input' # csrf_input_lazy(request)
+    * 'csrf_token' # csrf_token_lazy(request)
+
+
+Usage/configuration
+-------------------
+In your settings.py, change the TEMPLATE section to the following::
+
+    TEMPLATES = [
+        {
+            'BACKEND': 'django_genshi_template.backends.genshi.Genshi',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'auto_reload': False,
+                'app_dirname': 'genshi',
+                'serialization': 'html',
+                'doctype': 'html',
+            },
+        },
+    ]
+
+
+Questions with answers
+----------------------
+* How do I add additional context variables or functions that are available to every template?
+
+  Define a receiver function of the signal template_render and add context variables::
+
+        from django.dispatch import receiver
+        from django_template_backend_genshi import template_render
+
+        @receiver(template_render)
+        def add_render_globals(sender, **kwargs):
+            genshi_context = kwargs['genshi_context']
+            request = genshi_context['request']
+            genshi_context['mynewvar'] = type(request)
+

--- a/django_genshi_template/backends/genshi.py
+++ b/django_genshi_template/backends/genshi.py
@@ -27,15 +27,18 @@ class Genshi(BaseEngine):
         self.loader = TemplateLoader(self.template_dirs,
                                      auto_reload=auto_reload)
         self.serialization = options.get('serialization', 'html')
+        self.doctype = options.get('doctype', 'html')
 
     def from_string(self, template_code):
         return Template(MarkupTemplate(template_code),
-                        self.serialization)
+                        self.serialization,
+                        self.doctype)
 
     def get_template(self, template_name):
         try:
             return Template(self.loader.load(template_name),
-                            self.serialization)
+                            self.serialization,
+                            self.doctype)
         except TemplateNotFound as exc:
             six.reraise(TemplateDoesNotExist, TemplateDoesNotExist(exc.args),
                         sys.exc_info()[2])
@@ -46,9 +49,10 @@ class Genshi(BaseEngine):
 
 class Template(object):
 
-    def __init__(self, template, serialization):
+    def __init__(self, template, serialization, doctype):
         self.template = template
         self.serialization = serialization
+        self.doctype = doctype
 
     def render(self, context=None, request=None):
         if context is None:
@@ -58,4 +62,4 @@ class Template(object):
             context['request'] = request
             context['csrf_input'] = csrf_input_lazy(request)
             context['csrf_token'] = csrf_token_lazy(request)
-        return self.template.generate(**context).render(self.serialization, doctype='html')
+        return self.template.generate(**context).render(self.serialization, doctype=self.doctype)

--- a/django_genshi_template/backends/genshi.py
+++ b/django_genshi_template/backends/genshi.py
@@ -63,4 +63,6 @@ class Template(object):
         if context is not None:
             genshi_context.push(context)
         stream = self.template.generate(genshi_context)
+        # this might raise a genshi.template.eval.UndefinedError (derived from
+        # genshi.template.base.TemplateRuntimeError)
         return stream.render(self.serialization, doctype=self.doctype)

--- a/django_genshi_template/backends/genshi.py
+++ b/django_genshi_template/backends/genshi.py
@@ -9,7 +9,7 @@ from django.utils import six
 
 from genshi.template import TemplateLoader
 from genshi.template.base import TemplateSyntaxError \
-    as GenshiTemplateSyntaxError
+    as GenshiTemplateSyntaxError, Context as GenshiContext
 from genshi.template.loader import TemplateNotFound
 from genshi.template.markup import MarkupTemplate
 
@@ -55,11 +55,12 @@ class Template(object):
         self.doctype = doctype
 
     def render(self, context=None, request=None):
-        if context is None:
-            context = {}
-
+        genshi_context = GenshiContext()
         if request is not None:
-            context['request'] = request
-            context['csrf_input'] = csrf_input_lazy(request)
-            context['csrf_token'] = csrf_token_lazy(request)
-        return self.template.generate(**context).render(self.serialization, doctype=self.doctype)
+            genshi_context['request'] = request
+            genshi_context['csrf_input'] = csrf_input_lazy(request)
+            genshi_context['csrf_token'] = csrf_token_lazy(request)
+        if context is not None:
+            genshi_context.push(context)
+        stream = self.template.generate(genshi_context)
+        return stream.render(self.serialization, doctype=self.doctype)

--- a/django_genshi_template/backends/genshi.py
+++ b/django_genshi_template/backends/genshi.py
@@ -20,7 +20,8 @@ class Genshi(BaseEngine):
 
     def __init__(self, params):
         params = params.copy()
-        options = params.pop('OPTIONS').copy()  # NOQA
+        options = params.pop('OPTIONS').copy()
+        self.app_dirname = options.get('app_dirname', self.app_dirname)
         super(Genshi, self).__init__(params)
         self.loader = TemplateLoader(self.template_dirs)
 

--- a/django_genshi_template/backends/genshi.py
+++ b/django_genshi_template/backends/genshi.py
@@ -6,6 +6,8 @@ from django.template import TemplateDoesNotExist, TemplateSyntaxError
 from django.template.backends.base import BaseEngine
 from django.template.backends.utils import csrf_input_lazy, csrf_token_lazy
 from django.utils import six
+from django.core.urlresolvers import reverse
+from django.contrib.staticfiles.storage import staticfiles_storage
 
 from genshi.template import TemplateLoader
 from genshi.template.base import TemplateSyntaxError \
@@ -56,6 +58,8 @@ class Template(object):
 
     def render(self, context=None, request=None):
         genshi_context = GenshiContext()
+        genshi_context['static'] = staticfiles_storage.url
+        genshi_context['url'] = reverse
         if request is not None:
             genshi_context['request'] = request
             genshi_context['csrf_input'] = csrf_input_lazy(request)

--- a/django_genshi_template/backends/genshi.py
+++ b/django_genshi_template/backends/genshi.py
@@ -23,7 +23,9 @@ class Genshi(BaseEngine):
         options = params.pop('OPTIONS').copy()
         self.app_dirname = options.get('app_dirname', self.app_dirname)
         super(Genshi, self).__init__(params)
-        self.loader = TemplateLoader(self.template_dirs)
+        auto_reload = options.get('auto_reload', False)
+        self.loader = TemplateLoader(self.template_dirs,
+                                     auto_reload=auto_reload)
 
     def from_string(self, template_code):
         return Template(MarkupTemplate(template_code))


### PR DESCRIPTION
A friend of mine and I needed a Genshi template plugin for Django 1.8+ and at the time where we looked for it there was no git project. So we did our own plugin. A few days ago, we wanted to upload it to GitHub and discovered that you have done similar work (thanks). To avoid having two projects doing the same thing we coverted our code to a pull request to your project and "invite"/ask you to get this project forward together.
Our additions enable it to have function calls like "url" or "static" and "global" user-defined functions/variables available in the templates (like in the original Genshi template language).